### PR TITLE
BasePrelude Begone & Stack Buildable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+.stack-work

--- a/LDAP/Classy.hs
+++ b/LDAP/Classy.hs
@@ -42,9 +42,12 @@ module LDAP.Classy
   , module AttrTypes
   ) where
 
-import           BasePrelude               hiding (delete, first, insert, try)
+import           Prelude                   (Int, Show, fromIntegral, show)
 
+import           Control.Applicative       (Applicative, pure, (<$>))
+import           Control.Category          ((.))
 import           Control.Lens
+import           Control.Monad             ((>>), (>>=))
 import           Control.Monad.Catch       (try)
 import           Control.Monad.Error.Hoist ((<%!?>))
 import           Control.Monad.Error.Lens  (catching, throwing)
@@ -54,9 +57,18 @@ import           Control.Monad.IO.Class    (MonadIO, liftIO)
 import           Control.Monad.Reader      (MonadReader, ReaderT, runReaderT)
 import           Crypto.Password           (CharType (..), PasswordFeature (..),
                                             generatePassword)
+
+import           Data.Bool                 (Bool (..), not)
+import           Data.Either               (Either, either)
+import           Data.Foldable             (traverse_)
+import           Data.Function             (($))
+import           Data.Functor              (fmap)
+import           Data.List                 (filter, null)
+import           Data.Maybe                (Maybe (..))
 import           Data.Text                 (Text, pack)
 import           Data.Text.Lazy            (fromStrict)
 import           Data.Text.Lens
+import           Data.Tuple                (snd)
 import           LDAP                      (LDAP, LDAPEntry (..),
                                             LDAPException (..), LDAPMod (..),
                                             LDAPModOp (..), LDAPScope (..),
@@ -74,6 +86,7 @@ import           LDAP.Classy.Search        (LdapSearch, ldapSearchStr)
 import           LDAP.Classy.SSha          (toSSha)
 import           LDAP.Classy.Types         as Types
 import           Safe                      (headMay)
+import           System.IO                 (IO)
 
 data LdapCredentials = LdapCredentials
   { _ldapCredentialsDn       :: Dn

--- a/LDAP/Classy/AttributeValue.hs
+++ b/LDAP/Classy/AttributeValue.hs
@@ -1,20 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 module LDAP.Classy.AttributeValue where
 
-import Control.Applicative ((<$>),(<|>),pure,(*>))
-import Control.Monad.Reader (ReaderT,runReaderT,lift,ask)
-import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Base16 as BS16
-import Data.Foldable (foldMap,toList)
-import Data.List (nub)
-import Control.Monad (mzero)
-import Data.Attoparsec.Text (Parser,eitherResult,feed,parse,option,space,endOfInput,many1,peekChar)
-import Data.Semigroup ((<>))
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T(decodeUtf8) 
+import           Control.Applicative      ((<|>))
+import           Control.Monad            (mzero)
+import           Control.Monad.Reader     (ReaderT, ask, lift, runReaderT)
+import           Data.Attoparsec.Text     (Parser, eitherResult, endOfInput,
+                                           feed, many1, option, parse, peekChar,
+                                           space)
+import qualified Data.ByteString.Base16   as BS16
+import qualified Data.ByteString.Char8    as BS8
+import           Data.Foldable            (toList)
+import           Data.List                (nub)
+import           Data.Semigroup           ((<>))
+import           Data.Text                (Text)
+import qualified Data.Text                as T
+import qualified Data.Text.Encoding       as T (decodeUtf8)
 
-import LDAP.Classy.ParsingUtils (invalidStrCharSet,notInClassP,inClassP)
+import           LDAP.Classy.ParsingUtils (inClassP, invalidStrCharSet,
+                                           notInClassP)
 
 data DnValuePart = DnValueText Text | DnValueSpecial Char deriving Show
 
@@ -72,7 +75,7 @@ innerValueStrChar :: ReaderT String Parser Char
 innerValueStrChar = lift innerSpace <|> (ask >>= lift . notInClassP)
 
 specialChar :: ReaderT String Parser Char
-specialChar = ask >>= lift . inClassP 
+specialChar = ask >>= lift . inClassP
 
 innerSpace :: Parser Char
 innerSpace = do

--- a/LDAP/Classy/Decode.hs
+++ b/LDAP/Classy/Decode.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TupleSections         #-}
 module LDAP.Classy.Decode
   ( LdapEntryDecodeError(..)
   , FromLdapAttribute(..)
@@ -18,22 +18,35 @@ module LDAP.Classy.Decode
   , _AttributeFailedParse
   ) where
 
-import BasePrelude
+import           Prelude                   (Double, Int, Integer, Read, Show,
+                                            show, (==))
 
-import Control.Lens
-import Safe             (readMay,headMay)
-import Control.Monad.Except (MonadError)
-import Control.Monad.Error.Hoist ((<%?>),hoistError)
-import Control.Monad.Error.Lens (throwing)
-import Data.List.NonEmpty        (NonEmpty (..))
+import           Control.Applicative       (Applicative (..), pure)
+import           Control.Category          (id, (.))
+import           Control.Lens
+import           Control.Monad             ((=<<))
+import           Control.Monad.Error.Hoist (hoistError, (<%?>))
+import           Control.Monad.Error.Lens  (throwing)
+import           Control.Monad.Except      (MonadError)
+
+import           Safe                      (headMay, readMay)
+
+import           Data.Either               (Either (..))
+import           Data.Foldable             (find)
+import           Data.Function             (const, ($))
+import           Data.Functor              (Functor, fmap)
+import           Data.List.NonEmpty        (NonEmpty (..))
 import qualified Data.List.NonEmpty        as NEL
-import qualified Data.Text as T
-import qualified Data.Text.Lazy as TL
-import Data.Text.Lens (packed)
-import LDAP                      as L
+import           Data.Maybe                (Maybe (..), maybe)
+import           Data.String               (String)
+import qualified Data.Text                 as T
+import qualified Data.Text.Lazy            as TL
+import           Data.Text.Lens            (packed)
+import           Data.Tuple                (snd)
+import           LDAP                      as L
 
-import LDAP.Classy.Types
-import LDAP.Classy.Dn
+import           LDAP.Classy.Dn
+import           LDAP.Classy.Types
 
 data LdapEntryDecodeError
   = RequiredAttributeMissing LDAPEntry String
@@ -52,7 +65,7 @@ class FromLdapEntry a where
 
 class ToLdapEntry a where
   toLdapAttrs :: a -> [(String,[String])]
-  toLdapAttrs a = leattrs . toLdapEntry $ a
+  toLdapAttrs = leattrs . toLdapEntry
   toLdapDn :: a -> Dn
   toLdapDn = dnFromEntry . toLdapEntry
   toLdapEntry :: a -> LDAPEntry
@@ -163,7 +176,7 @@ instance ToLdapAttribute String where
   toLdapAttribute = id
 
 instance FromLdapEntry LDAPEntry where
-  fromLdapEntry = pure 
+  fromLdapEntry = pure
 
 instance ToLdapEntry LDAPEntry where
   toLdapEntry = id

--- a/LDAP/Classy/Dn.hs
+++ b/LDAP/Classy/Dn.hs
@@ -20,19 +20,31 @@ module LDAP.Classy.Dn
   , dnFromEntry
   ) where
 
-import           BasePrelude             hiding ((<>))
+import           Prelude                   (Show, error, show, (&&), (-), (/=),
+                                            (<), (==))
 
-import           Control.Lens            (Getter, Prism', prism', to)
-import           Data.Attoparsec.Text    (eitherResult, feed, parse)
-import           Data.List.NonEmpty      (NonEmpty ((:|)))
-import qualified Data.List.NonEmpty      as NEL
-import           Data.Semigroup          ((<>))
-import           Data.Text               (Text)
-import qualified Data.Text               as T
-import           LDAP                    (LDAPEntry (..))
+import           Control.Category          ((.))
+import           Control.Lens              (Getter, Prism', prism', to)
 
-import           LDAP.Classy.Dn.Internal
+import           Data.Attoparsec.Text      (eitherResult, feed, parse)
+import           Data.Bool                 (Bool (..))
+import           Data.Either               (Either, either)
+import           Data.Foldable             (length)
+import           Data.Function             (const, flip, ($))
+import           Data.Functor              (fmap)
+import           Data.List                 (drop)
+import           Data.List.NonEmpty        (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty        as NEL
+import           Data.Maybe                (Maybe (..), fromMaybe)
+import           Data.Semigroup            ((<>))
+import           Data.String               (String)
+import           Data.Text                 (Text)
+import qualified Data.Text                 as T
+
+import           LDAP                      (LDAPEntry (..))
+
 import           LDAP.Classy.AttributeType (AttributeType)
+import           LDAP.Classy.Dn.Internal
 import           LDAP.Classy.Dn.Types
 
 dnCons :: RelativeDn -> Dn -> Dn

--- a/LDAP/Classy/Dn/Internal.hs
+++ b/LDAP/Classy/Dn/Internal.hs
@@ -3,24 +3,33 @@
 {-# LANGUAGE TupleSections     #-}
 module LDAP.Classy.Dn.Internal where
 
-import           BasePrelude            hiding ((<>))
+import           Prelude                    (read)
 
-import           Data.Attoparsec.Text   (Parser, char, endOfInput,
-                                         many1, manyTill,
-                                         notInClass, 
-                                         peekChar, satisfy, sepBy, sepBy1,
-                                         skipMany)
-import           Data.ByteString.Base16 as B16
-import qualified Data.List.NonEmpty     as NEL
-import           Data.Semigroup         (Semigroup (..))
-import           Data.Text              (Text)
-import qualified Data.Text              as T
-import qualified Data.Text.Encoding     as T
+import           Control.Applicative        (pure, (*>), (<$>), (<*), (<*>),
+                                             (<|>))
+import           Control.Category           ((.))
+import           Control.Monad              (mzero, return)
+import           Data.Attoparsec.Text       (Parser, char, endOfInput, many',
+                                             many1, manyTill, notInClass,
+                                             peekChar, satisfy, sepBy, sepBy1,
+                                             skipMany)
+import           Data.ByteString.Base16     as B16
+import           Data.Char                  (Char)
+import           Data.Foldable              (toList)
+import           Data.Function              (($))
+import           Data.Functor               (fmap)
+import qualified Data.List.NonEmpty         as NEL
+import           Data.Maybe                 (Maybe (..))
+import           Data.Semigroup             (Semigroup (..))
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import qualified Data.Text.Encoding         as T
+import           Data.Tuple                 (fst)
 
-import           LDAP.Classy.Dn.Types
 import           LDAP.Classy.AttributeType
 import           LDAP.Classy.AttributeValue
-import           LDAP.Classy.ParsingUtils    (invalidStrCharSet,inClassP)
+import           LDAP.Classy.Dn.Types
+import           LDAP.Classy.ParsingUtils   (inClassP, invalidStrCharSet)
 
 -- The logic for encoding / decoding the strings can be found here:
 -- https://tools.ietf.org/html/rfc4514
@@ -69,7 +78,7 @@ descr :: Parser AttributeType
 descr = do
   t <- T.cons
     <$> alpha
-    <*> (T.pack <$> many (alpha <|> digit <|> hyphen))
+    <*> (T.pack <$> many' (alpha <|> digit <|> hyphen))
   pure $ case T.toUpper t of
     "L"      -> LocalityName
     "CN"     -> CommonName

--- a/LDAP/Classy/Dn/Types.hs
+++ b/LDAP/Classy/Dn/Types.hs
@@ -1,7 +1,6 @@
 module LDAP.Classy.Dn.Types where
 
 import           Data.List.NonEmpty (NonEmpty)
-import           Data.Monoid        (Monoid (mappend, mempty))
 import           Data.Semigroup     (Semigroup ((<>)))
 import           Data.Text          (Text)
 

--- a/LDAP/Classy/SSha.hs
+++ b/LDAP/Classy/SSha.hs
@@ -6,15 +6,25 @@
 {-# LANGUAGE TypeFamilies          #-}
 module LDAP.Classy.SSha where
 
-import BasePrelude
+import           Prelude                     (Eq, Int, Show,show,(==))
 
-import Control.Lens
-import Data.ByteString.Base64.Lazy (encode)
-import Data.ByteString.Lazy        (ByteString, pack)
-import Data.Digest.Pure.SHA        (bytestringDigest, sha1)
-import Data.Text.Lazy              (Text, unpack)
-import Data.Text.Lazy.Encoding     (decodeUtf8, encodeUtf8)
-import System.Random               (getStdRandom, random)
+import           Control.Applicative         ((<$>))
+import           Control.Category            ((.))
+import           Control.Lens
+import           Control.Monad               (replicateM)
+
+import           Data.Bool                   (Bool (..))
+import           Data.ByteString.Base64.Lazy (encode)
+import           Data.ByteString.Lazy        (ByteString, pack)
+import           Data.Digest.Pure.SHA        (bytestringDigest, sha1)
+import           Data.Function               (flip, ($))
+import           Data.Functor                (fmap)
+import           Data.Monoid                 ((<>))
+import           Data.Text.Lazy              (Text, unpack)
+import           Data.Text.Lazy.Encoding     (decodeUtf8, encodeUtf8)
+
+import           System.IO                   (IO)
+import           System.Random               (getStdRandom, random)
 
 newtype Salt = Salt ByteString deriving Eq
 makeWrapped ''Salt

--- a/LDAP/Classy/Search.hs
+++ b/LDAP/Classy/Search.hs
@@ -19,19 +19,29 @@ module LDAP.Classy.Search
   , isPosixGroup
   ) where
 
-import BasePrelude        hiding (first, try, (<>))
-import Data.Text          (pack,unpack)
-import Data.List.NonEmpty (NonEmpty (..), (<|))
-import Data.Semigroup     ((<>))
+import           Control.Applicative        (pure)
+import           Control.Category           ((.))
+import           Prelude                    (Show, (==))
 
-import LDAP.Classy.AttributeValue (escapeAttrValueTextExtraEscape)
+import           Data.Bool                  (Bool (..))
+import           Data.Foldable              (foldMap)
+import           Data.Function              (($))
+import           Data.Functor               (fmap)
+import           Data.List                  (drop, isPrefixOf, isSuffixOf,
+                                             reverse)
+import           Data.List.NonEmpty         (NonEmpty (..), (<|))
+import           Data.Semigroup             ((<>))
+import           Data.String                (IsString (..), String)
+import           Data.Text                  (pack, unpack)
+
+import           LDAP.Classy.AttributeValue (escapeAttrValueTextExtraEscape)
 
 -- It's worthwhile checking out these RFCs:
 -- - https://tools.ietf.org/html/rfc4512
 -- - https://tools.ietf.org/html/rfc4515
 
 -- Lots of things aren't implemented here, sadly:
--- TODO: Putting a search in the middle of a string (cn ==. "Ben*Kolera") currently escapes to cn=Ben\*Kolera. 
+-- TODO: Putting a search in the middle of a string (cn ==. "Ben*Kolera") currently escapes to cn=Ben\*Kolera.
 -- TODO: Any kind of safety around the keys. You can break things by going "cn=" ==. "foo".
 -- TODO: Extensible Matches
 -- TODO: Substring searches
@@ -187,7 +197,7 @@ infixl 2 ||.
 -- >>> "a" <-. (ExactMatch "a") :| [ExactMatch "b",Unanchored "c"]
 -- LdapOr (LdapMatch "a" (ExactMatch "a") :| [LdapMatch "a" (ExactMatch "b"),LdapMatch "a" (Unanchored "c")])
 in_,(<-.) :: String -> NonEmpty MatchExpr -> LdapSearch
-in_ k ss = LdapOr . fmap (LdapMatch k) $ ss
+in_ k = LdapOr . fmap (LdapMatch k)
 
 (<-.) = in_
 

--- a/LDAP/Classy/Types.hs
+++ b/LDAP/Classy/Types.hs
@@ -6,10 +6,10 @@
 {-# LANGUAGE TypeFamilies               #-}
 module LDAP.Classy.Types where
 
-import BasePrelude
-
-import Control.Lens
-import Data.Text    (Text)
+import           Control.Lens
+import           Data.String  (IsString)
+import           Data.Text    (Text)
+import           Prelude      (Eq, Int, Num, Show)
 
 newtype Uid = Uid Text deriving (Show,IsString,Eq)
 makeWrapped ''Uid

--- a/ldap-classy.cabal
+++ b/ldap-classy.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                ldap-classy
-version:             0.5.2.1
+version:             0.6.0.0
 synopsis:            An opinionated typeclassy layer on top of the LDAP library.
 -- description:
 homepage:            https://github.com/benkolera/haskell-ldap-classy

--- a/ldap-classy.cabal
+++ b/ldap-classy.cabal
@@ -35,26 +35,25 @@ library
     , LDAP.Classy.ParsingUtils
     , LDAP.Classy.AttributeValue
   build-depends:
-      base >=4.7 && <4.9
-    , base-prelude
+      base              >=4.8 && < 5
     , attoparsec        == 0.13.*
-    , base64-bytestring == 1.0.*
-    , bifunctors        == 4.2.*
+    , base64-bytestring == 1.*
+    , bifunctors        == 5.*
     , bytestring        == 0.10.*
     , base16-bytestring == 0.1.*
-    , exceptions        >= 0.6 && < 0.9
+    , exceptions        == 0.8.*
     , hoist-error       == 0.1.*
-    , lens              == 4.8.*
+    , lens              >= 4.13
     , LDAP              == 0.6.*
     , mtl               == 2.2.*
     , passwords         == 0.1.*
-    , random            == 1.1.*
+    , random            == 1.*
     , safe              == 0.3.*
-    , semigroups        == 0.16.*
+    , semigroups        == 0.18.*
     , SHA               == 1.6.*
     , text              == 1.2.*
     , transformers      == 0.4.*
-  ghc-options: -Wall 
+  ghc-options: -Wall
   default-language:    Haskell2010
 
 executable example
@@ -65,53 +64,58 @@ executable example
   else
     buildable: False
   build-depends:
-      base                  >=4.7 && <4.9
+      base                 >=4.8 && < 5
     , ldap-classy
-    , base-prelude
-    , bifunctors            == 4.2.*
-    , hoist-error           == 0.1.*
-    , lens                  == 4.8.*
-    , LDAP                  == 0.6.*
-    , mtl                   == 2.2.*
-    , optparse-applicative
-    , semigroups            == 0.16.*
-    , text                  == 1.2.*
-    , UtilityTM             == 0.0.*
+    , bifunctors           == 5.*
+    , hoist-error          == 0.1.*
+    , lens                 >= 4.13
+    , LDAP                 == 0.6.*
+    , mtl                  == 2.2.*
+    , optparse-applicative == 0.12.*
+    , semigroups           == 0.18.*
+    , text                 == 1.2.*
+    , UtilityTM            == 0.0.4
   default-language:    Haskell2010
 
 test-suite tasty
   default-language: Haskell2010
+  other-modules: LDAP.Classy.AttributeType
+                 LDAP.Classy.AttributeValue
+                 LDAP.Classy.Dn
+                 LDAP.Classy.Dn.Internal
+                 LDAP.Classy.Dn.Types
+                 LDAP.Classy.ParsingUtils
+                 Test.LDAP.Classy.Dn
   type: exitcode-stdio-1.0
   hs-source-dirs: tests, .
   main-is: Tasty.hs
   ghc-options: -Wall -Werror -fwarn-tabs
   build-depends:
       base              >= 4     && < 5
-    , tasty             >= 0.10
-    , tasty-hunit       >= 0.9.2
-    , base-prelude
-    , attoparsec        == 0.13.*
-    , base64-bytestring == 1.0.*
-    , bifunctors        == 4.2.*
-    , bytestring        == 0.10.*
-    , base16-bytestring == 0.1.*
-    , exceptions        >= 0.6 && < 0.9
-    , hlint             == 1.9.*
-    , hoist-error       == 0.1.*
-    , lens              == 4.8.*
-    , LDAP              == 0.6.*
-    , mtl               == 2.2.*
-    , passwords         == 0.1.*
-    , random            == 1.1.*
-    , safe              == 0.3.*
-    , semigroups        == 0.16.*
-    , SHA               == 1.6.*
-    , text              == 1.2.*
-    , transformers      == 0.4.*
+    , tasty
+    , tasty-hunit
+    , attoparsec
+    , base64-bytestring
+    , bifunctors
+    , bytestring
+    , base16-bytestring
+    , exceptions
+    , hlint
+    , hoist-error
+    , lens
+    , LDAP
+    , mtl
+    , passwords
+    , random
+    , safe
+    , semigroups
+    , SHA
+    , text
+    , transformers
 
--- Won't work until ghc 7.10
--- test-suite doctests
---   type:          exitcode-stdio-1.0
---   ghc-options:   -threaded
---   main-is:       tests/Doctests.hs
---  build-depends: base, doctest >= 0.8
+test-suite doctests
+  default-language: Haskell2010
+  type:          exitcode-stdio-1.0
+  ghc-options:   -threaded
+  main-is:       tests/Doctests.hs
+ build-depends: base, doctest >= 0.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,15 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+- location:
+    git: https://github.com/tonymorris/utility-tm
+    commit: 22457f0454fc69137061dd47aae2fd66c3b83b65
+- location:
+    git: https://github.com/alephcloud/hs-hoist-error
+    commit: a87bfc962a55a8270c522ba06d98707a9914b998
+extra-deps:
+- LDAP-0.6.10
+- passwords-0.1.0.6
+- text-1.2.2.0
+resolver: lts-5.3

--- a/tests/Test/LDAP/Classy/Dn.hs
+++ b/tests/Test/LDAP/Classy/Dn.hs
@@ -4,7 +4,7 @@ module Test.LDAP.Classy.Dn (dnTests) where
 import           Test.Tasty              (TestTree, testGroup)
 import           Test.Tasty.HUnit        (Assertion, testCase, (@?=))
 
-import           Control.Applicative     ((*>), (<*), (<|>))
+import           Control.Applicative     ((<|>))
 import           Data.Attoparsec.Text    (Parser, eitherResult, endOfInput,
                                           feed, option, parse)
 import           Data.Foldable           (traverse_)


### PR DESCRIPTION
The dependency of BasePrelude has been removed, all of the (I'm reasonably sure I found everything) references to it have been removed. 

Explicit imports have been maintained where I could to bring things in from their respective homes.

The tests that 'won't work until 7.10' now work and have been uncommented.

Import lists have had 'stylish-haskell' liberally applied.

A swathe of dependencies have been either removed or bumped.

Commensurately, the version of the library has been bumped to 0.6.0.0.
